### PR TITLE
Bugfix for homebrew path issue

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -5,7 +5,7 @@
 	<key>bundleid</key>
 	<string>de.chris-grieser.shimmering-obsidian</string>
 	<key>category</key>
-	<string>App-Enhance</string>
+	<string>Personal Workflow</string>
 	<key>connections</key>
 	<dict>
 		<key>07C4D3F5-5CBC-4BAF-9004-B506BEF11C23</key>
@@ -1625,7 +1625,7 @@
 				<key>escaping</key>
 				<integer>63</integer>
 				<key>script</key>
-				<string>export PATH=/usr/local/bin/:$PATH
+				<string>export PATH="$homebrew_path":$PATH
 
 temp_image="$alfred_workflow_cache""/temp_ocr_snapshot.png"
 mkdir -p "$alfred_workflow_cache"
@@ -1658,11 +1658,11 @@ tesseract "$temp_image" stdout -l $ocr_languages 2&gt;&amp;1</string>
 				<key>focusedappvariablename</key>
 				<string></string>
 				<key>hotkey</key>
-				<integer>18</integer>
+				<integer>29</integer>
 				<key>hotmod</key>
 				<integer>1179648</integer>
 				<key>hotstring</key>
-				<string>1</string>
+				<string>À</string>
 				<key>leftcursor</key>
 				<false/>
 				<key>modsmode</key>
@@ -1810,11 +1810,9 @@ tesseract "$temp_image" stdout -l $ocr_languages 2&gt;&amp;1</string>
 				<key>focusedappvariablename</key>
 				<string></string>
 				<key>hotkey</key>
-				<integer>32</integer>
+				<integer>0</integer>
 				<key>hotmod</key>
-				<integer>1966080</integer>
-				<key>hotstring</key>
-				<string>U</string>
+				<integer>0</integer>
 				<key>leftcursor</key>
 				<false/>
 				<key>modsmode</key>
@@ -2018,8 +2016,6 @@ echo -n "$base64encoded"</string>
 				<integer>0</integer>
 				<key>hotmod</key>
 				<integer>0</integer>
-				<key>hotstring</key>
-				<string></string>
 				<key>leftcursor</key>
 				<false/>
 				<key>modsmode</key>
@@ -4696,6 +4692,8 @@ Created by @pspeudometa (Discord) aka @chrisgrieser (GitHub).
 ---
 
 # Release Notes
+v. 1.2.1 beta
+- proposed bugfix for `homebrew installation path` issue
 
 v. 1.2
 - bugfix for `odual` command
@@ -5934,36 +5932,38 @@ DOUBLE CLICK THIS to set hotkey</string>
 	<key>variables</key>
 	<dict>
 		<key>backup_destination</key>
-		<string>~/Google Drive/Dokumente/IT Backups/Obsidian Backups</string>
+		<string></string>
 		<key>fontformat</key>
 		<string>woff2</string>
+		<key>homebrew_path</key>
+		<string>/opt/homebrew/bin/</string>
 		<key>max_number_of_bkps</key>
 		<string>15</string>
 		<key>ocr_languages</key>
-		<string>deu+eng</string>
+		<string>fra+eng</string>
 		<key>search_ignore_attachments</key>
 		<string>true</string>
 		<key>template_note_path</key>
-		<string>~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Vault/Functionality/QuickAdd/Basic Template.md</string>
+		<string></string>
 		<key>thousand_seperator</key>
-		<string>.</string>
+		<string> </string>
 		<key>toggle_snippet</key>
-		<string>~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Vault/.obsidian/snippets/Hide URLs.css</string>
+		<string></string>
 		<key>use_quickadd</key>
-		<string>true</string>
+		<string></string>
 		<key>vault_path</key>
-		<string>~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Vault</string>
+		<string></string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>
-		<string>toggle_snippet</string>
-		<string>vault_path</string>
 		<string>backup_destination</string>
-		<string>template_note_path</string>
 		<string>use_quickadd</string>
+		<string>template_note_path</string>
+		<string>vault_path</string>
+		<string>toggle_snippet</string>
 	</array>
 	<key>version</key>
-	<string>1.2</string>
+	<string>1.2.1_beta_homebrew_fix</string>
 	<key>webaddress</key>
 	<string>https://chris-grieser.de/</string>
 </dict>


### PR DESCRIPTION
Added a homebrew_path variable to be populated with the particular homebrew installation path.
Changed the OCR script to reference this variable when calling the tesseract app.