### PR TITLE
add a value for date and time format in OCR-ss

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>bundleid</key>
 	<string>de.chris-grieser.shimmering-obsidian</string>
-	<key>category</key>
-	<string>App-Enhance</string>
 	<key>connections</key>
 	<dict>
 		<key>07C4D3F5-5CBC-4BAF-9004-B506BEF11C23</key>
@@ -1817,7 +1815,7 @@
 				<key>filename</key>
 				<string>{var:vault_path}/OCR-Screenshot.md</string>
 				<key>filetext</key>
-				<string>{date:yyyy-MM-dd}, {time:HH:mm}
+				<string>{var:ocr_datetime_format}
 
 ---
 {query}
@@ -1878,11 +1876,9 @@ tesseract "$temp_image" stdout -l $ocr_languages 2&gt;&amp;1</string>
 				<key>focusedappvariablename</key>
 				<string></string>
 				<key>hotkey</key>
-				<integer>18</integer>
+				<integer>0</integer>
 				<key>hotmod</key>
-				<integer>1179648</integer>
-				<key>hotstring</key>
-				<string>1</string>
+				<integer>0</integer>
 				<key>leftcursor</key>
 				<false/>
 				<key>modsmode</key>
@@ -2023,11 +2019,9 @@ tesseract "$temp_image" stdout -l $ocr_languages 2&gt;&amp;1</string>
 				<key>focusedappvariablename</key>
 				<string></string>
 				<key>hotkey</key>
-				<integer>32</integer>
+				<integer>0</integer>
 				<key>hotmod</key>
-				<integer>1966080</integer>
-				<key>hotstring</key>
-				<string>U</string>
+				<integer>0</integer>
 				<key>leftcursor</key>
 				<false/>
 				<key>modsmode</key>
@@ -2212,8 +2206,6 @@ echo -n "$base64encoded"</string>
 				<integer>0</integer>
 				<key>hotmod</key>
 				<integer>0</integer>
-				<key>hotstring</key>
-				<string></string>
 				<key>leftcursor</key>
 				<false/>
 				<key>modsmode</key>
@@ -4306,6 +4298,25 @@ echo -n `cat "$vault_path""/.obsidian/appearance.json" | grep "cssTheme" | head 
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>externaltriggerid</key>
+				<string>update-obsidian-workflow</string>
+				<key>passinputasargument</key>
+				<true/>
+				<key>passvariables</key>
+				<true/>
+				<key>workflowbundleid</key>
+				<string>self</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.callexternaltrigger</string>
+			<key>uid</key>
+			<string>5C1918E9-6508-4076-8D79-716B47ACFC20</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>alfredfiltersresults</key>
 				<true/>
 				<key>alfredfiltersresultsmatchmode</key>
@@ -4351,25 +4362,6 @@ echo -n `cat "$vault_path""/.obsidian/appearance.json" | grep "cssTheme" | head 
 			<string>6A8AE7C9-2FE9-45DD-8CCC-69B6146E26F7</string>
 			<key>version</key>
 			<integer>3</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>externaltriggerid</key>
-				<string>update-obsidian-workflow</string>
-				<key>passinputasargument</key>
-				<true/>
-				<key>passvariables</key>
-				<true/>
-				<key>workflowbundleid</key>
-				<string>self</string>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.output.callexternaltrigger</string>
-			<key>uid</key>
-			<string>5C1918E9-6508-4076-8D79-716B47ACFC20</string>
-			<key>version</key>
-			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -6389,25 +6381,27 @@ DOUBLE CLICK THIS to set hotkey</string>
 	<key>variables</key>
 	<dict>
 		<key>backup_destination</key>
-		<string>~/Google Drive/Dokumente/IT Backups/Obsidian Backups</string>
+		<string></string>
 		<key>fontformat</key>
 		<string>woff2</string>
 		<key>max_number_of_bkps</key>
 		<string>15</string>
+		<key>ocr_datetime_format</key>
+		<string>{date:yyyy-MM-dd}, {time:HH:mm}</string>
 		<key>ocr_languages</key>
 		<string>deu+eng</string>
 		<key>search_ignore_attachments</key>
 		<string>true</string>
 		<key>template_note_path</key>
-		<string>~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Vault/Functionality/QuickAdd/Basic Template.md</string>
+		<string></string>
 		<key>thousand_seperator</key>
 		<string>.</string>
 		<key>toggle_snippet</key>
-		<string>~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Vault/.obsidian/snippets/Hide URLs.css</string>
+		<string></string>
 		<key>use_quickadd</key>
-		<string>false</string>
+		<string></string>
 		<key>vault_path</key>
-		<string>~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Vault</string>
+		<string></string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>


### PR DESCRIPTION
Added a ocr_datetime_format variable and set default as "{date:yyyy-MM-dd}, {time:HH:mm}", related to #6 .
I think this is more generic, and at the same time, this will not annoy many users.

Please consider using.

Regards,

<img src="https://i.gyazo.com/ccd5d322adfa2b5c53085a2663e5d998.png" width=40%>
<img src="https://i.gyazo.com/523ae9cb8768fa036c46c93047cac740.png" width=40%>


