### PR TITLE
Fix malformed link to "Note-related features" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please refer to [the Breaking Changes Docs](documentation/Breaking%20Changes.md)
 - Move Note to a different folder
 - Daily Notes
 
-➡️ [Documentation of Note-related Features](documentation/Note-related%Features.md)
+➡️ [Documentation of Note-related Features](documentation/Note-related%20Features.md)
 
 ### Screenshot Features
 - OCR Screenshots


### PR DESCRIPTION
Hello and thanks for this awesome workflow! While going through the docs I noticed a malformed link in the readme, and thought I'd create a quick PR to fix it :)

Cheers!