### PR TITLE
Change condition to check files in .trash

### DIFF
--- a/scripts/obsidian-backup.sh
+++ b/scripts/obsidian-backup.sh
@@ -13,7 +13,7 @@ cd "$vault"
 mkdir "$vault"/.trash
 
 itemCount=$(ls "$vault"/.trash | wc -l)
-if [[ "$itemCount" != "0" ]] ; then
+if (( ${itemCount} != 0 )) ; then
 	zip -r --quiet "$backup" ./* ./.obsidian/* ./.trash/*
 else
 	zip -r --quiet "$backup" ./* ./.obsidian/*


### PR DESCRIPTION
Fix for #55 - changed the if statement in the backup script so that it does not always evaluate to "true"