### PR TITLE
Fix bug for the Obsidian < 0.16

### DIFF
--- a/scripts/o_search.js
+++ b/scripts/o_search.js
@@ -33,7 +33,7 @@ const metadataJSON = vaultPath + "/.obsidian/plugins/metadata-extractor/metadata
 const starredJSON = vaultPath + "/.obsidian/starred.json";
 const excludeFilterJSON = vaultPath + "/.obsidian/app.json";
 let recentJSON = vaultPath + "/.obsidian/workspace.json";
-if (!fileExists(recentJSON)) recentJSON = recentJSON.slice(-5); // Obsidian 0.16 uses workspace.json → https://discord.com/channels/686053708261228577/716028884885307432/1013906018578743478
+if (!fileExists(recentJSON)) recentJSON = recentJSON.slice(0, -5); // Obsidian 0.16 uses workspace.json → https://discord.com/channels/686053708261228577/716028884885307432/1013906018578743478
 const jsonArray = [];
 
 // Supercharged Icons File


### PR DESCRIPTION
slice(-5) return only the last 5 letters, e.g "workspace.json".slice(-5) returns '.json'.