### PR TITLE
Alfred-based Quick Switcher.md: Fix bases to basis

### DIFF
--- a/docs/Alfred-based Quick Switcher.md
+++ b/docs/Alfred-based Quick Switcher.md
@@ -25,7 +25,7 @@ The Alfred-based Quick Switcher is basically an enhanced version of [Obsidian's 
 <!--toc:end-->
 
 ## How the Search works
-All the search features listed here do not *directly* search your vault, but rather use the metadata created by the [Metadata Extractor Plugin](https://obsidian.md/plugins?id=metadata-extractor) on a regular bases. By default, this happens every 30 minutes, meaning recently created notes, recently renamed notes, or recent tag changes are not picked up at once. You can change the meta data refresh rate via the Metadata Extractor Plugin's settings.
+All the search features listed here do not *directly* search your vault, but rather use the metadata created by the [Metadata Extractor Plugin](https://obsidian.md/plugins?id=metadata-extractor) on a regular basis. By default, this happens every 30 minutes, meaning recently created notes, recently renamed notes, or recent tag changes are not picked up at once. You can change the meta data refresh rate via the Metadata Extractor Plugin's settings.
 
 ## Main Search
 **`o`: Open files in your vault.**


### PR DESCRIPTION
*Bases* is the correct plural, but it seems you want the singular here.