### PR TITLE
Update WikiLink syntax to unencoded and fix heading bug

### DIFF
--- a/scripts/copy-note-link.js
+++ b/scripts/copy-note-link.js
@@ -14,7 +14,7 @@ function run(argv) {
 
 	// import variables
 	let [relativePath, heading] = argv[0].split("#");
-	relativePath = encodeURIComponent(relativePath);
+	relativeEncodedPath = encodeURIComponent(relativePath);
 	heading = encodeURIComponent(heading);
 	const linkType = $.getenv("link_type_to_copy");
 
@@ -23,16 +23,16 @@ function run(argv) {
 	let filenameNoExt = relativePath.split("/").pop().replace(/\.\w+$/, "");
 	let toCopy;
 
-	if (linkType === "Markdown Link" && heading) {
-		const urlScheme = `obsidian://advanced-uri?vault=${vaultNameEnc}&filepath=${relativePath}&heading=${heading}`;
+	if (linkType === "Markdown Link" && heading && heading != 'undefined' ) {
+		const urlScheme = `obsidian://advanced-uri?vault=${vaultNameEnc}&filepath=${relativeEncodedPath}&heading=${heading}`;
 		filenameNoExt += "|" + heading;
 		toCopy = `[${filenameNoExt}](${urlScheme})`;
-	} else if (linkType === "Markdown Link" && !heading) {
-		const urlScheme = `obsidian://open?vault=${vaultNameEnc}&file=${relativePath}`;
+	} else if (linkType === "Markdown Link") {
+		const urlScheme = `obsidian://open?vault=${vaultNameEnc}&file=${relativeEncodedPath}`;
 		toCopy = `[${filenameNoExt}](${urlScheme})`;
-	} else if (linkType === "Wikilink" && heading) {
+	} else if (linkType === "Wikilink" && heading && heading != 'undefined' ) {
 		toCopy = `[[${filenameNoExt}#${heading}]]`;
-	} else if (linkType === "Wikilink" && !heading) {
+	} else if (linkType === "Wikilink") {
 		toCopy = `[[${filenameNoExt}]]`;
 	}
 


### PR DESCRIPTION
## Markdown Link title and WikiLink without URI encoding 

Markdown Links (which include the `obsidian://` URL scheme) keep the URI encoding for the file path while also using the unencoded version for the Display. WikiLinks do not need to be URI encoded at all. 

This change will ensure that WikiLinks are thus created in the unencoded form and that this will also be used for the displayed text in Markdown Links. I acknowledge there might have been a design decision to use URI encoding both for the displayed title as well as the file in the Obsidian URI – if this is the case happy to discuss and understand.

The linkt to a file named `My Fabulous Obsidian File.md` in Obsidian is currently rendered as follows (Markdown link and WikiLink, respectively):

```
[My%20Fabulous%20Obsidian%20File](obsidian://advanced-uri?vault=VAULT&file=My%20Fabulous%20Obsidian%20File.md)
[[My%20Fabulous%20Obsidian%20File]]
```

Whereas with the change, it will be 

```
[My Fabulous Obsidian File](obsidian://advanced-uri?vault=VAULT&file=My%20Fabulous%20Obsidian%20File.md)
[[My Fabulous Obsidian File]]
```

## Fix for a "heading" bug

I always get the `#heading` version, even if no heading is selected in Alfred. When debugging the script, I saw it processed a string value of `undefined` on my Systems. This contains an attempt to fix this by testing for "heading" and its value instead of testing for an empty / non empty variable. This was with newer versions of macOS Sonoma, and the newest Alfred Version.