### PR TITLE
Fix screenshots opening

### DIFF
--- a/scripts/screenshot-to-note.sh
+++ b/scripts/screenshot-to-note.sh
@@ -5,6 +5,7 @@
 
 mkdir -p "$screenshot_path"
 imageFileName="Screenshot $(date '+%Y-%m-%d %H-%M-%S').png"
+imagePath="$screenshot_path/$imageFileName"
 
 screencapture -i "$screenshot_path/$imageFileName"
 echo "![[$imageFileName]]" >> "$vault_path/Images.md"

--- a/scripts/screenshot-to-note.sh
+++ b/scripts/screenshot-to-note.sh
@@ -7,7 +7,10 @@ mkdir -p "$screenshot_path"
 imageFileName="Screenshot $(date '+%Y-%m-%d %H-%M-%S').png"
 imagePath="$screenshot_path/$imageFileName"
 
-screencapture -i "$screenshot_path/$imageFileName"
-echo "![[$imageFileName]]" >> "$vault_path/Images.md"
+screencapture -i "$imagePath"
 
-[[ -e "$imagePath" ]] && echo -n "Screenshot made"
+if [[ -e "$imagePath" ]] ; then
+    echo "![[$imageFileName]]" >> "$vault_path/Images.md"
+
+    echo -n "Screenshot made"
+fi


### PR DESCRIPTION
`imagePath` is undefined leading to missing success notifications and opening of the screenshot in context.

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` and the internal workflow documentation.
