### PR TITLE
Add support for blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ change the metadata refresh rate via the Metadata Extractor Plugin's settings.
 
 ### Main search
 **`o`: Open files in your vault.**
-This keyword searches all your notes, aliases, folders, and headings combined.
+This keyword searches all your notes, aliases, folders, blocks, and headings combined.
 
 #### Search for notes
 This works similar to Obsidian's built-in *Quick Switcher*, but can be triggered
@@ -123,7 +123,7 @@ note).
 
 #### Smart queries
 - Add `filename` or `title` to your search query, to display only files and no
-  aliases, folders, or headings. For example, `o obsidian filename` displays
+  aliases, folders, blocks, or headings. For example, `o obsidian filename` displays
   only notes that have the `obsidian` in their filename.
 - Add `canvas` to your search to only display canvases (Obsidian 1.1).
 - Similarly, you can also filter for starred or recent files by adding `starred`

--- a/scripts/o_search.js
+++ b/scripts/o_search.js
@@ -251,6 +251,30 @@ function run() {
 				},
 			});
 		}
+
+		// Blocks
+		if (!file.blocks) continue; // skips iteration if no blocks
+		for (const block of file.blocks) {
+			const bTitle = block.block;
+			const bId = block.id;
+			const blockIconpath = `icons/link.png`;
+			const matchStr = camelCaseMatch(bTitle) + `${bId}`;
+
+			resultsArr[insertVia]({
+				title: bTitle,
+				match: matchStr,
+				subtitle: "➣ " + filename + "(" + bId + ")",
+				arg: relativePath + "#^" + bId,
+				uid: relativePath + "#^" + bId,
+				quicklookurl: absolutePath,
+				icon: { path: blockIconpath },
+				mods: {
+					alt: { arg: relativePath },
+					shift: { arg: relativePath },
+				},
+			});
+		}
+
 	}
 
 	// CANVASES

--- a/scripts/open-note.js
+++ b/scripts/open-note.js
@@ -33,7 +33,10 @@ function run(argv) {
 	// determine input
 	const input = (argv[0] || "").trim(); // trim to remove trailing \n
 	const relativePath = (input.split("#")[0] || "").split(":")[0] || "";
-	const heading = input.split("#")[1];
+ let heading = input.split("#")[1];
+	const block = input.split("#^")[1];
+	// if we have a block ,then unset the heading
+	if (block) heading = null
 	const lineNum = input.split(":")[1]; // used by `oe` external link search to open at line
 
 	// DOCS https://vinzent03.github.io/obsidian-advanced-uri/concepts/navigation_parameters#open-mode
@@ -47,6 +50,7 @@ function run(argv) {
 		`vault=${vaultNameEnc}`,
 		`&filepath=${encodeURIComponent(relativePath)}`,
 		heading ? "&heading=" + encodeURIComponent(heading) : "",
+		block ? "&block=" + encodeURIComponent(block) : "",
 		lineNum ? "&line=" + encodeURIComponent(lineNum) : "",
 		openMode ? "&openmode=" + openMode : "",
 	];


### PR DESCRIPTION
## What problem does this PR solve?
- Adds support for opening obsidian blocks
- This is a **draft proposal** that depends on this **draft proposal**:
- kometenstaub/metadata-extractor/pull/26

## How does the PR solve it?
- parses the (proposed) block section from the extracted metadata
- this enables querying the blocks
- uses the `&block=block-id` URI to open blocks correctly
- It adds supports to callouts blocks but someone could extend it to support more generic blocks as well.


## Checklist
- [x] Used only `camelCase` variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` and the internal workflow documentation.
