### PR TITLE
feat: allow searching across all vaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ note).
 
 > [!TIP]
 > There are various settings for appending and opening notes, which can be found
-> in the workflow configuration.
+> in the workflow configuration. You can also configure the workflow to search
+> across all of your Obsidian vaults rather than just the active one by enabling
+> the `Search all vaults` setting.
 
 #### Smart queries
 - Add `filename` or `title` to your search query, to display only files and no

--- a/info.plist
+++ b/info.plist
@@ -7107,6 +7107,25 @@ DOUBLE CLICK THIS to set Hotkey. Suggested Hotkey: cmd + shift + 1</string>
 			<key>config</key>
 			<dict>
 				<key>default</key>
+				<false/>
+				<key>required</key>
+				<false/>
+				<key>text</key>
+				<string>Search all vaults</string>
+			</dict>
+			<key>description</key>
+			<string>Search for notes and canvases across all of your Obsidian vaults rather than just the active one.</string>
+			<key>label</key>
+			<string></string>
+			<key>type</key>
+			<string>checkbox</string>
+			<key>variable</key>
+			<string>search_all_vaults</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
 				<string>h1 h5 h6</string>
 				<key>placeholder</key>
 				<string>h1 h5 h6</string>

--- a/info.plist
+++ b/info.plist
@@ -3118,6 +3118,8 @@ set parameter to do shell script "echo " &amp; quoted form of (system attribute 
 				<true/>
 				<key>variables</key>
 				<dict>
+					<key>current_vault_path</key>
+					<string>{var:folder_vault_path}</string>
 					<key>current_folder</key>
 					<string>{var:browse_folder}</string>
 				</dict>
@@ -5447,7 +5449,7 @@ curl -sL "https://raw.githubusercontent.com/chrisgrieser/alfred-docs-searches/ma
 	</array>
 	<key>readme</key>
 	<string>## 1️⃣ Setting up this workflow for the first time
-1. Install the Obsidian plugins [Advanced URI](https://obsidian.md/plugins?id=obsidian-advanced-uri) &amp; [Metadata Extractor](https://obsidian.md/plugins?id=metadata-extractor). 
+1. Install the Obsidian plugins [Advanced URI](https://obsidian.md/plugins?id=obsidian-advanced-uri) &amp; [Metadata Extractor](https://obsidian.md/plugins?id=metadata-extractor).
 2. Enable both plugins.
 3. Set your vault path in the configuration to the left.
 
@@ -5460,7 +5462,7 @@ curl -sL "https://raw.githubusercontent.com/chrisgrieser/alfred-docs-searches/ma
 
 ## ⚙️ Workflow Configuration
 - **Some features require additional configuration to the left.** You can get further information on those features at the respective sections of the [documentation](https://github.com/chrisgrieser/shimmering-obsidian/blob/main/README.md).
-- To configure the hotkeys, double-click the [sky-blue fields](https://i.imgur.com/wlpht7f.png) at the top left of the workflow window. 
+- To configure the hotkeys, double-click the [sky-blue fields](https://i.imgur.com/wlpht7f.png) at the top left of the workflow window.
 
 ## Links
 - 📙 [Changelog](https://github.com/chrisgrieser/shimmering-obsidian/releases)

--- a/scripts/new-note-in-folder.js
+++ b/scripts/new-note-in-folder.js
@@ -25,7 +25,7 @@ const fileExists = (/** @type {string} */ filePath) => Application("Finder").exi
 /** @type {AlfredRun} */
 // biome-ignore lint/correctness/noUnusedVariables: Alfred run
 function run() {
-	const vaultPath = $.getenv("vault_path");
+	const vaultPath = $.getenv("current_vault_path");
 	const vaultNameEnc = encodeURIComponent(vaultPath.replace(/.*\//, ""));
 	const relativePath = $.getenv("current_folder") + "/Untitled.md";
 	let newNoteAbsPath = `${vaultPath}/${relativePath}`;

--- a/scripts/o_search.js
+++ b/scripts/o_search.js
@@ -270,7 +270,18 @@ function createFolderItem(absolutePath, vaultPath) {
 	};
 }
 
-/** @type {AlfredRun} */
+/**
+ * Environment variables:
+ *
+ * - vault_path: workflow's active vault path.
+ * - config_folder: The Obsidian configuration folder (e.g., ".obsidian").
+ * - main_search_subtitle: The type of subtitle to display ("parent" or "tags").
+ * - remove_emojis: Set to "1" to remove emojis from search results.
+ * - browse_folder: (optional) The relative path of a subfolder to search within.
+ * - h_lvl_ignore: Heading levels to ignore (e.g., "123").
+ *
+ * @type {AlfredRun}
+ */
 // biome-ignore lint/correctness/noUnusedVariables: Alfred run
 function run() {
 	const vaultPath = $.getenv("vault_path");

--- a/scripts/o_search.js
+++ b/scripts/o_search.js
@@ -260,6 +260,9 @@ function createFolderItem(absolutePath, vaultPath) {
 		type: "file:skipcheck",
 		uid: relativePath,
 		icon: { path: "icons/folder.png" },
+		variables: {
+			folder_vault_path: vaultPath,
+		},
 		mods: {
 			alt: { subtitle: "⌥: Open Folder in Finder" },
 			cmd: denyForFolder,
@@ -277,7 +280,10 @@ function createFolderItem(absolutePath, vaultPath) {
  * - config_folder: The Obsidian configuration folder (e.g., ".obsidian").
  * - main_search_subtitle: The type of subtitle to display ("parent" or "tags").
  * - remove_emojis: Set to "1" to remove emojis from search results.
- * - browse_folder: (optional) The relative path of a subfolder to search within.
+ * - browse_folder: (optional) The path of a subfolder to search within.
+ *   Can be undefined, "/", or a relative path signifying the subfolder mode.
+ * - current_vault_path: (optional) The vault path for the subfolder mode.
+ *   Must be set for for the subfolder mode.
  * - h_lvl_ignore: Heading levels to ignore (e.g., "123").
  *
  * @type {AlfredRun}
@@ -307,16 +313,20 @@ function run() {
 	//──────────────────────────────────────────────────────────────────────────────
 	// DETERMINE PATH TO SEARCH
 	let currentFolder = "";
-	let pathToSearch;
+	let pathToSearch = vaultPath;
+	let isInSubfolder = false;
 	// either searches the vault, or a subfolder of the vault
 	try {
-		currentFolder = $.getenv("browse_folder");
-		pathToSearch = vaultPath + "/" + currentFolder;
-		if (pathToSearch.endsWith("//")) pathToSearch = vaultPath; // when going back up from child of vault root
+		const currentFolderVaultPath =
+			$.NSProcessInfo.processInfo.environment.objectForKey("current_vault_path").js;
+		currentFolder = $.NSProcessInfo.processInfo.environment.objectForKey("browse_folder").js;
+		if (currentFolder !== "/" && currentFolder !== undefined) {
+			isInSubfolder = true;
+			pathToSearch = currentFolderVaultPath + "/" + currentFolder;
+		}
 	} catch (_error) {
-		pathToSearch = vaultPath;
+		// ignore
 	}
-	const isInSubfolder = pathToSearch !== vaultPath;
 
 	// returns *absolute* paths
 	let folderArray = app
@@ -425,6 +435,9 @@ function run() {
 			subtitle: "▸ " + parentFolder(currentFolder),
 			arg: parentFolder(currentFolder),
 			icon: { path: "icons/folder.png" },
+			variables: {
+				folder_vault_path: vaultPath,
+			},
 		});
 	}
 	if (resultsArr.length === 0) {

--- a/scripts/o_search.js
+++ b/scripts/o_search.js
@@ -29,29 +29,15 @@ const fileExists = (/** @type {string} */ filePath) => Application("Finder").exi
 
 //──────────────────────────────────────────────────────────────────────────────
 
-/** @type {AlfredRun} */
-// biome-ignore lint/correctness/noUnusedVariables: Alfred run
-function run() {
-	const vaultPath = $.getenv("vault_path");
-	const configFolder = $.getenv("config_folder");
+function getVaultData(vaultPath, configFolder) {
 	const vaultConfig = `${vaultPath}/${configFolder}`;
-
-	if (!fileExists(vaultConfig)) {
-		const errorItem = {
-			title: `🚫 Vault config folder "${configFolder}" not found.`,
-			subtitle: "Set the correct config folder in the workflow configuration.",
-			valid: false,
-		};
-		return JSON.stringify({ items: [errorItem] });
-	}
+	if (!fileExists(vaultConfig)) return null;
 
 	const metadataJSON = `${vaultConfig}/plugins/metadata-extractor/metadata.json`;
 	const canvasJSON = `${vaultConfig}/plugins/metadata-extractor/canvas.json`;
 	const starredJSON = `${vaultConfig}/starred.json`;
 	const bookmarkJSON = `${vaultConfig}/bookmarks.json`;
 	const excludeFilterJSON = `${vaultConfig}/app.json`;
-	const removeEmojis = $.getenv("remove_emojis") === "1";
-	const subtitleType = $.getenv("main_search_subtitle");
 
 	let recentJSON = `${vaultConfig}/workspace.json`;
 	if (!fileExists(recentJSON)) recentJSON = recentJSON.slice(0, -5); // Obsidian 0.16 uses workspace.json → https://discord.com/channels/686053708261228577/716028884885307432/1013906018578743478
@@ -60,7 +46,7 @@ function run() {
 		? JSON.parse(readFile(excludeFilterJSON)).userIgnoreFilters
 		: [];
 	const recentFiles = fileExists(recentJSON) ? JSON.parse(readFile(recentJSON)).lastOpenFiles : [];
-	let canvasArray = fileExists(canvasJSON) ? JSON.parse(readFile(canvasJSON)) : [];
+	const canvasArray = fileExists(canvasJSON) ? JSON.parse(readFile(canvasJSON)) : [];
 
 	//───────────────────────────────────────────────────────────────────────────
 	// Main Metadata
@@ -72,7 +58,7 @@ function run() {
 		};
 		return JSON.stringify({ items: [errorItem] });
 	}
-	let fileArray = JSON.parse(readFile(metadataJSON));
+	const fileArray = JSON.parse(readFile(metadataJSON));
 
 	//──────────────────────────────────────────────────────────────────────────────
 	// BOOKMARKS & STARS
@@ -104,6 +90,41 @@ function run() {
 		bmFlatten(bookm, bookmarks);
 	}
 	const starsAndBookmarks = [...new Set([...stars, ...bookmarks])];
+	const vaultName = vaultPath.split("/").pop();
+
+	return {
+		vaultPath,
+		vaultName,
+		fileArray,
+		canvasArray,
+		starsAndBookmarks,
+		recentFiles,
+		excludeFilter,
+	};
+}
+
+/** @type {AlfredRun} */
+// biome-ignore lint/correctness/noUnusedVariables: Alfred run
+function run() {
+	const vaultPath = $.getenv("vault_path");
+	const configFolder = $.getenv("config_folder");
+	const vaultConfig = `${vaultPath}/${configFolder}`;
+
+	if (!fileExists(vaultConfig)) {
+		const errorItem = {
+			title: `🚫 Vault config folder "${configFolder}" not found.`,
+			subtitle: "Set the correct config folder in the workflow configuration.",
+			valid: false,
+		};
+		return JSON.stringify({ items: [errorItem] });
+	}
+
+	const removeEmojis = $.getenv("remove_emojis") === "1";
+	const subtitleType = $.getenv("main_search_subtitle");
+
+	const vaultData = getVaultData(vaultPath, configFolder);
+	if (typeof vaultData === "string") return vaultData; // error message
+	let { fileArray, canvasArray, starsAndBookmarks, recentFiles, excludeFilter } = vaultData;
 
 	//──────────────────────────────────────────────────────────────────────────────
 	// DETERMINE PATH TO SEARCH

--- a/scripts/o_search.js
+++ b/scripts/o_search.js
@@ -103,6 +103,173 @@ function getVaultData(vaultPath, configFolder) {
 	};
 }
 
+/**
+ * @param {any} file
+ * @param {string} vaultPath
+ * @param {string[]} starsAndBookmarks
+ * @param {string[]} recentFiles
+ * @param {boolean} removeEmojis
+ * @param {string} subtitleType
+ * @param {boolean[]} headingIgnore
+ * @returns {AlfredItem[]}
+ */
+function createFileItems(
+	file,
+	vaultPath,
+	starsAndBookmarks,
+	recentFiles,
+	removeEmojis,
+	subtitleType,
+	headingIgnore,
+) {
+	const items = [];
+	const filename = file.fileName;
+	const relativePath = file.relativePath;
+	const absolutePath = vaultPath + "/" + relativePath;
+	const isBookmarked = starsAndBookmarks.includes(relativePath);
+	const isRecent = recentFiles.includes(relativePath);
+	const isPrioritized = isRecent || isBookmarked;
+
+	// matching for Alfred
+	const tagMatcher = file.tags ? " #" + file.tags.join(" #") : "";
+	let additionalMatcher = "";
+	if (isRecent) additionalMatcher += " recent";
+	if (isBookmarked) additionalMatcher += " starred bookmarked";
+
+	// icon & emojis
+	let iconpath = "icons/note.png";
+	let emoji = "";
+	if (isBookmarked) emoji += "🔖 ";
+	if (isRecent) emoji += "🕑 ";
+	if (filename.toLowerCase().includes("kanban")) iconpath = "icons/kanban.png";
+	if (removeEmojis) emoji = "";
+
+	const subtitle =
+		subtitleType === "parent"
+			? "▸ " + parentFolder(relativePath)
+			: (file.tags || []).map((/** @type {string} */ t) => "#" + t).join(" ");
+
+	// Notes (file names)
+	items.push({
+		title: emoji + filename,
+		match: camelCaseMatch(filename) + tagMatcher + " filename name title" + additionalMatcher,
+		subtitle: subtitle,
+		arg: relativePath,
+		quicklookurl: absolutePath,
+		type: "file:skipcheck",
+		uid: relativePath,
+		icon: { path: iconpath },
+		isPrioritized: isPrioritized,
+	});
+
+	// Aliases
+	if (file.aliases) {
+		for (const alias of file.aliases) {
+			items.push({
+				title: emoji + alias,
+				match: camelCaseMatch(alias) + "alias",
+				subtitle: "↪ " + alias,
+				arg: relativePath,
+				quicklookurl: absolutePath,
+				type: "file:skipcheck",
+				uid: alias + "_" + relativePath,
+				icon: { path: "icons/alias.png" },
+				isPrioritized: isPrioritized,
+			});
+		}
+	}
+
+	// Headings
+	if (file.headings) {
+		for (const heading of file.headings) {
+			const hName = heading.heading;
+			const hLevel = heading.level;
+			if (headingIgnore[hLevel]) continue; // skips iteration if heading has been configured as ignore
+			const headingIconpath = `icons/headings/h${hLevel}.png`;
+			const matchStr = camelCaseMatch(hName) + `h${hLevel}`;
+
+			items.push({
+				title: hName,
+				match: matchStr,
+				subtitle: "➣ " + filename,
+				arg: relativePath + "#" + hName,
+				uid: relativePath + "#" + hName,
+				quicklookurl: absolutePath,
+				icon: { path: headingIconpath },
+				mods: {
+					alt: { arg: relativePath },
+					shift: { arg: relativePath },
+				},
+				isPrioritized: isPrioritized,
+			});
+		}
+	}
+
+	return items;
+}
+
+/**
+ * @param {any} canvas
+ * @param {string[]} starsAndBookmarks
+ * @param {string[]} recentFiles
+ * @returns {AlfredItem}
+ */
+function createCanvasItem(canvas, starsAndBookmarks, recentFiles) {
+	const name = canvas.basename;
+	const relativePath = canvas.relativePath;
+	const isBookmarked = starsAndBookmarks.includes(relativePath);
+	const isRecent = recentFiles.includes(relativePath);
+
+	// matching for Alfred
+	let additionalMatcher = "";
+	if (isRecent) additionalMatcher += " recent";
+	if (isBookmarked) additionalMatcher += " starred bookmarked";
+
+	return {
+		title: name,
+		match: camelCaseMatch(name) + "canvas" + additionalMatcher,
+		subtitle: "▸ " + parentFolder(relativePath),
+		arg: relativePath,
+		type: "file:skipcheck",
+		icon: { path: "icons/canvas.png" },
+		uid: relativePath,
+		mods: {
+			shift: { valid: false, subtitle: "⛔ Cannot do that with a canvas." },
+			fn: { valid: false, subtitle: "⛔ Cannot do that with a canvas." },
+		},
+		isPrioritized: isRecent || isBookmarked,
+	};
+}
+
+/**
+ * @param {string} absolutePath
+ * @param {string} vaultPath
+ * @returns {AlfredItem | null}
+ */
+function createFolderItem(absolutePath, vaultPath) {
+	const name = absolutePath.split("/").pop();
+	const relativePath = absolutePath.slice(vaultPath.length + 1);
+	if (!name) return null; // root on 2 level deep folder search
+
+	const denyForFolder = { valid: false, subtitle: "⛔ Cannot do that with a folder." };
+	return {
+		title: name,
+		match: camelCaseMatch(name) + "folder",
+		subtitle: "▸ " + parentFolder(relativePath) + "   [↵: Browse]",
+		arg: relativePath,
+		type: "file:skipcheck",
+		uid: relativePath,
+		icon: { path: "icons/folder.png" },
+		mods: {
+			alt: { subtitle: "⌥: Open Folder in Finder" },
+			cmd: denyForFolder,
+			shift: denyForFolder,
+			ctrl: denyForFolder,
+			fn: denyForFolder,
+		},
+	};
+}
+
 /** @type {AlfredRun} */
 // biome-ignore lint/correctness/noUnusedVariables: Alfred run
 function run() {
@@ -200,142 +367,34 @@ function run() {
 
 	// FILES
 	for (const file of fileArray) {
-		const filename = file.fileName;
-		const relativePath = file.relativePath;
-		const absolutePath = vaultPath + "/" + relativePath;
-		const isBookmarked = starsAndBookmarks.includes(relativePath);
-		const isRecent = recentFiles.includes(relativePath);
-
-		// matching for Alfred
-		const tagMatcher = file.tags ? " #" + file.tags.join(" #") : "";
-		let additionalMatcher = "";
-		if (isRecent) additionalMatcher += " recent";
-		if (isBookmarked) additionalMatcher += " starred bookmarked";
-
-		// pprioritization of sorting
-		const prioritzedSorting = isRecent || isBookmarked;
-		const insertVia = prioritzedSorting ? "unshift" : "push";
-
-		// icon & emojis
-		let iconpath = "icons/note.png";
-		let emoji = "";
-		if (isBookmarked) emoji += "🔖 ";
-		if (isRecent) emoji += "🕑 ";
-		if (filename.toLowerCase().includes("kanban")) iconpath = "icons/kanban.png";
-		if (removeEmojis) emoji = "";
-
-		const subtitle =
-			subtitleType === "parent"
-				? "▸ " + parentFolder(relativePath)
-				: (file.tags || []).map((/** @type {string} */ t) => "#" + t).join(" ");
-
-		// Notes (file names)
-		resultsArr[insertVia]({
-			title: emoji + filename,
-			match: camelCaseMatch(filename) + tagMatcher + " filename name title" + additionalMatcher,
-			subtitle: subtitle,
-			arg: relativePath,
-			quicklookurl: absolutePath,
-			type: "file:skipcheck",
-			uid: relativePath,
-			icon: { path: iconpath },
-		});
-
-		// Aliases
-		if (file.aliases) {
-			for (const alias of file.aliases) {
-				resultsArr[insertVia]({
-					title: emoji + alias,
-					match: camelCaseMatch(alias) + "alias",
-					subtitle: "↪ " + alias,
-					arg: relativePath,
-					quicklookurl: absolutePath,
-					type: "file:skipcheck",
-					uid: alias + "_" + relativePath,
-					icon: { path: "icons/alias.png" },
-				});
-			}
-		}
-
-		// Headings
-		if (!file.headings) continue; // skips iteration if no heading
-		for (const heading of file.headings) {
-			const hName = heading.heading;
-			const hLevel = heading.level;
-			if (headingIgnore[hLevel]) continue; // skips iteration if heading has been configured as ignore
-			const headingIconpath = `icons/headings/h${hLevel}.png`;
-			const matchStr = camelCaseMatch(hName) + `h${hLevel}`;
-
-			resultsArr[insertVia]({
-				title: hName,
-				match: matchStr,
-				subtitle: "➣ " + filename,
-				arg: relativePath + "#" + hName,
-				uid: relativePath + "#" + hName,
-				quicklookurl: absolutePath,
-				icon: { path: headingIconpath },
-				mods: {
-					alt: { arg: relativePath },
-					shift: { arg: relativePath },
-				},
-			});
+		const fileItems = createFileItems(
+			file,
+			vaultPath,
+			starsAndBookmarks,
+			recentFiles,
+			removeEmojis,
+			subtitleType,
+			headingIgnore,
+		);
+		for (const item of fileItems) {
+			const isPrioritized = item.isPrioritized;
+			delete item.isPrioritized;
+			resultsArr[isPrioritized ? "unshift" : "push"](item);
 		}
 	}
 
 	// CANVASES
 	for (const canvas of canvasArray) {
-		const name = canvas.basename;
-		const relativePath = canvas.relativePath;
-		const isBookmarked = starsAndBookmarks.includes(relativePath);
-		const isRecent = recentFiles.includes(relativePath);
-
-		// matching for Alfred
-		let additionalMatcher = "";
-		if (isRecent) additionalMatcher += " recent";
-		if (isBookmarked) additionalMatcher += " starred bookmarked";
-
-		// pprioritization of sorting
-		const prioritzedSorting = isRecent || isBookmarked;
-		const insertMode = prioritzedSorting ? "unshift" : "push";
-
-		resultsArr[insertMode]({
-			title: name,
-			match: camelCaseMatch(name) + "canvas" + additionalMatcher,
-			subtitle: "▸ " + parentFolder(relativePath),
-			arg: relativePath,
-			type: "file:skipcheck",
-			icon: { path: "icons/canvas.png" },
-			uid: relativePath,
-			mods: {
-				shift: { valid: false, subtitle: "⛔ Cannot do that with a canvas." },
-				fn: { valid: false, subtitle: "⛔ Cannot do that with a canvas." },
-			},
-		});
+		const canvasItem = createCanvasItem(canvas, starsAndBookmarks, recentFiles);
+		const isPrioritized = canvasItem.isPrioritized;
+		delete canvasItem.isPrioritized;
+		resultsArr[isPrioritized ? "unshift" : "push"](canvasItem);
 	}
 
 	// FOLDERS
 	for (const absolutePath of folderArray) {
-		const denyForFolder = { valid: false, subtitle: "⛔ Cannot do that with a folder." };
-		const name = absolutePath.split("/").pop();
-		const relativePath = absolutePath.slice(vaultPath.length + 1);
-		if (!name) continue; // root on 2 level deep folder search
-
-		resultsArr.push({
-			title: name,
-			match: camelCaseMatch(name) + "folder",
-			subtitle: "▸ " + parentFolder(relativePath) + "   [↵: Browse]",
-			arg: relativePath,
-			type: "file:skipcheck",
-			uid: relativePath,
-			icon: { path: "icons/folder.png" },
-			mods: {
-				alt: { subtitle: "⌥: Open Folder in Finder" },
-				cmd: denyForFolder,
-				shift: denyForFolder,
-				ctrl: denyForFolder,
-				fn: denyForFolder,
-			},
-		});
+		const folderItem = createFolderItem(absolutePath, vaultPath);
+		if (folderItem) resultsArr.push(folderItem);
 	}
 
 	// ADDITIONAL OPTIONS WHEN BROWSING A FOLDER

--- a/scripts/o_search.js
+++ b/scripts/o_search.js
@@ -28,6 +28,22 @@ function camelCaseMatch(str) {
 const fileExists = (/** @type {string} */ filePath) => Application("Finder").exists(Path(filePath));
 
 //──────────────────────────────────────────────────────────────────────────────
+/**
+ * Gets the paths of all vaults configured in Obsidian by reading the obsidian.json file.
+ *
+ * @returns {string[]} An array of vault paths.
+ */
+function getVaultPaths() {
+	const vaultListJson =
+		app.pathTo("home folder") + "/Library/Application Support/obsidian/obsidian.json";
+	if (!fileExists(vaultListJson)) return [];
+	const vaultList = JSON.parse(readFile(vaultListJson)).vaults;
+	const vaultPaths = [];
+	for (const hash in vaultList) {
+		vaultPaths.push(vaultList[hash].path);
+	}
+	return vaultPaths;
+}
 
 function getVaultData(vaultPath, configFolder) {
 	const vaultConfig = `${vaultPath}/${configFolder}`;
@@ -159,6 +175,7 @@ function createFileItems(
 		type: "file:skipcheck",
 		uid: relativePath,
 		icon: { path: iconpath },
+		variables: { note_vault_path: vaultPath },
 		isPrioritized: isPrioritized,
 	});
 
@@ -174,6 +191,7 @@ function createFileItems(
 				type: "file:skipcheck",
 				uid: alias + "_" + relativePath,
 				icon: { path: "icons/alias.png" },
+				variables: { note_vault_path: vaultPath },
 				isPrioritized: isPrioritized,
 			});
 		}
@@ -200,6 +218,7 @@ function createFileItems(
 					alt: { arg: relativePath },
 					shift: { arg: relativePath },
 				},
+				variables: { note_vault_path: vaultPath },
 				isPrioritized: isPrioritized,
 			});
 		}
@@ -233,6 +252,7 @@ function createCanvasItem(canvas, starsAndBookmarks, recentFiles) {
 		type: "file:skipcheck",
 		icon: { path: "icons/canvas.png" },
 		uid: relativePath,
+		variables: { note_vault_path: vaultPath },
 		mods: {
 			shift: { valid: false, subtitle: "⛔ Cannot do that with a canvas." },
 			fn: { valid: false, subtitle: "⛔ Cannot do that with a canvas." },
@@ -285,93 +305,22 @@ function createFolderItem(absolutePath, vaultPath) {
  * - current_vault_path: (optional) The vault path for the subfolder mode.
  *   Must be set for for the subfolder mode.
  * - h_lvl_ignore: Heading levels to ignore (e.g., "123").
+ * - search_all_vaults: (optional) Set to "1" to search all vaults instead of just the active one.
  *
  * @type {AlfredRun}
  */
 // biome-ignore lint/correctness/noUnusedVariables: Alfred run
 function run() {
-	const vaultPath = $.getenv("vault_path");
 	const configFolder = $.getenv("config_folder");
-	const vaultConfig = `${vaultPath}/${configFolder}`;
-
-	if (!fileExists(vaultConfig)) {
-		const errorItem = {
-			title: `🚫 Vault config folder "${configFolder}" not found.`,
-			subtitle: "Set the correct config folder in the workflow configuration.",
-			valid: false,
-		};
-		return JSON.stringify({ items: [errorItem] });
-	}
-
 	const removeEmojis = $.getenv("remove_emojis") === "1";
 	const subtitleType = $.getenv("main_search_subtitle");
+	const searchAllVaults =
+		$.NSProcessInfo.processInfo.environment.objectForKey("search_all_vaults").js === "1";
 
-	const vaultData = getVaultData(vaultPath, configFolder);
-	if (typeof vaultData === "string") return vaultData; // error message
-	let { fileArray, canvasArray, starsAndBookmarks, recentFiles, excludeFilter } = vaultData;
-
-	//──────────────────────────────────────────────────────────────────────────────
-	// DETERMINE PATH TO SEARCH
-	let currentFolder = "";
-	let pathToSearch = vaultPath;
-	let isInSubfolder = false;
-	// either searches the vault, or a subfolder of the vault
-	try {
-		const currentFolderVaultPath =
-			$.NSProcessInfo.processInfo.environment.objectForKey("current_vault_path").js;
-		currentFolder = $.NSProcessInfo.processInfo.environment.objectForKey("browse_folder").js;
-		if (currentFolder !== "/" && currentFolder !== undefined) {
-			isInSubfolder = true;
-			pathToSearch = currentFolderVaultPath + "/" + currentFolder;
-		}
-	} catch (_error) {
-		// ignore
+	let vaultsToSearch = [$.getenv("vault_path")];
+	if (searchAllVaults) {
+		vaultsToSearch = getVaultPaths();
 	}
-
-	// returns *absolute* paths
-	let folderArray = app
-		.doShellScript(`find "${pathToSearch}" -type d -mindepth 1 -not -path "*/.*"`)
-		.split("\r");
-	if (folderArray[0] === "") folderArray = [];
-
-	//──────────────────────────────────────────────────────────────────────────────
-	// EXCLUSION & IGNORING
-
-	// if in subfolder, filter files outside subfolder
-	if (isInSubfolder) {
-		fileArray = fileArray.filter((/** @type {{ relativePath: string; }} */ file) =>
-			file.relativePath.startsWith(currentFolder),
-		);
-		canvasArray = canvasArray.filter((/** @type {{ relativePath: string; }} */ file) =>
-			file.relativePath.startsWith(currentFolder),
-		);
-		// INFO folderarray does not need to be filtered, since already filtered on creation
-	}
-
-	/**
-	 * @param {(string|{relativePath: string})[]} items if folder, object list otherwise
-	 * @param {boolean} isFolder
-	 * @return {(string|{relativePath: string})[]}
-	 */
-	function applyExcludeFilter(items, isFolder) {
-		if (!excludeFilter || excludeFilter.length === 0 || items.length === 0) return items;
-		return items.filter((item) => {
-			let include = true;
-			// @ts-expect-error
-			const path = isFolder ? item + "/" : item.relativePath;
-			for (const filter of excludeFilter) {
-				const isRegexFilter = filter.startsWith("/");
-				const relPath = isFolder ? path.slice(vaultPath.length + 1) : path;
-				if (isRegexFilter && relPath.includes(filter)) include = false;
-				if (!isRegexFilter && relPath.startsWith(filter)) include = false;
-			}
-			return include;
-		});
-	}
-
-	folderArray = applyExcludeFilter(folderArray, true);
-	canvasArray = applyExcludeFilter(canvasArray, false);
-	fileArray = applyExcludeFilter(fileArray, false);
 
 	// ignored headings
 	const hLVLignore = $.getenv("h_lvl_ignore");
@@ -381,65 +330,171 @@ function run() {
 		headingIgnore[i] = shouldIgnore;
 	}
 
-	//──────────────────────────────────────────────────────────────────────────────
-	// CONSTRUCTION OF JSON FOR ALFRED
 	/** @type {AlfredItem[]} */
 	const resultsArr = [];
 
-	// FILES
-	for (const file of fileArray) {
-		const fileItems = createFileItems(
-			file,
-			vaultPath,
-			starsAndBookmarks,
-			recentFiles,
-			removeEmojis,
-			subtitleType,
-			headingIgnore,
-		);
-		for (const item of fileItems) {
-			const isPrioritized = item.isPrioritized;
-			delete item.isPrioritized;
-			resultsArr[isPrioritized ? "unshift" : "push"](item);
+	let currentFolder = "";
+	let isInSubfolder = false;
+	// either searches the vault, or a subfolder of the vault
+	try {
+		const currentFolderVaultPath =
+			$.NSProcessInfo.processInfo.environment.objectForKey("current_vault_path").js;
+		currentFolder = $.NSProcessInfo.processInfo.environment.objectForKey("browse_folder").js;
+		if (currentFolder !== "/" && currentFolder !== undefined) {
+			isInSubfolder = true;
+			// When browsing a folder, we only search in that specific vault and folder
+			vaultsToSearch = [currentFolderVaultPath];
+		}
+	} catch (_error) {
+		// ignore
+	}
+
+	for (const vaultPath of vaultsToSearch) {
+		const vaultConfig = `${vaultPath}/${configFolder}`;
+
+		if (!fileExists(vaultConfig)) {
+			// Skip vaults that don't have the config folder instead of erroring out when searching all vaults
+			if (!searchAllVaults) {
+				const errorItem = {
+					title: `🚫 Vault config folder "${configFolder}" not found.`,
+					subtitle: "Set the correct config folder in the workflow configuration.",
+					valid: false,
+				};
+				return JSON.stringify({ items: [errorItem] });
+			}
+			continue;
+		}
+
+		const vaultData = getVaultData(vaultPath, configFolder);
+		if (!vaultData || typeof vaultData === "string") {
+			if (!searchAllVaults && typeof vaultData === "string") return vaultData;
+			continue;
+		}
+		let { fileArray, canvasArray, starsAndBookmarks, recentFiles, excludeFilter, vaultName } =
+			vaultData;
+
+		//──────────────────────────────────────────────────────────────────────────────
+		// DETERMINE PATH TO SEARCH
+		let pathToSearch = vaultPath;
+		if (isInSubfolder) {
+			pathToSearch = vaultPath + "/" + currentFolder;
+		}
+
+		// returns *absolute* paths
+		let folderArray = app
+			.doShellScript(`find "${pathToSearch}" -type d -mindepth 1 -not -path "*/.*"`)
+			.split("\r");
+		if (folderArray[0] === "") folderArray = [];
+
+		//──────────────────────────────────────────────────────────────────────────────
+		// EXCLUSION & IGNORING
+
+		// if in subfolder, filter files outside subfolder
+		if (isInSubfolder) {
+			fileArray = fileArray.filter((/** @type {{ relativePath: string; }} */ file) =>
+				file.relativePath.startsWith(currentFolder),
+			);
+			canvasArray = canvasArray.filter((/** @type {{ relativePath: string; }} */ file) =>
+				file.relativePath.startsWith(currentFolder),
+			);
+			// INFO folderarray does not need to be filtered, since already filtered on creation
+		}
+
+		/**
+		 * @param {(string|{relativePath: string})[]} items if folder, object list otherwise
+		 * @param {boolean} isFolder
+		 * @return {(string|{relativePath: string})[]}
+		 */
+		function applyExcludeFilter(items, isFolder) {
+			if (!excludeFilter || excludeFilter.length === 0 || items.length === 0) return items;
+			return items.filter((item) => {
+				let include = true;
+				// @ts-expect-error
+				const path = isFolder ? item + "/" : item.relativePath;
+				for (const filter of excludeFilter) {
+					const isRegexFilter = filter.startsWith("/");
+					const relPath = isFolder ? path.slice(vaultPath.length + 1) : path;
+					if (isRegexFilter && relPath.includes(filter)) include = false;
+					if (!isRegexFilter && relPath.startsWith(filter)) include = false;
+				}
+				return include;
+			});
+		}
+
+		folderArray = applyExcludeFilter(folderArray, true);
+		canvasArray = applyExcludeFilter(canvasArray, false);
+		fileArray = applyExcludeFilter(fileArray, false);
+
+		//──────────────────────────────────────────────────────────────────────────────
+		// CONSTRUCTION OF JSON FOR ALFRED
+
+		// FILES
+		for (const file of fileArray) {
+			const fileItems = createFileItems(
+				file,
+				vaultPath,
+				starsAndBookmarks,
+				recentFiles,
+				removeEmojis,
+				subtitleType,
+				headingIgnore,
+			);
+			for (const item of fileItems) {
+				const isPrioritized = item.isPrioritized;
+				delete item.isPrioritized;
+				if (searchAllVaults) {
+					item.subtitle = `[${vaultName}] ` + item.subtitle;
+				}
+				resultsArr[isPrioritized ? "unshift" : "push"](item);
+			}
+		}
+
+		// CANVASES
+		for (const canvas of canvasArray) {
+			const canvasItem = createCanvasItem(canvas, starsAndBookmarks, recentFiles);
+			const isPrioritized = canvasItem.isPrioritized;
+			delete canvasItem.isPrioritized;
+			if (searchAllVaults) {
+				canvasItem.subtitle = `[${vaultName}] ` + canvasItem.subtitle;
+			}
+			resultsArr[isPrioritized ? "unshift" : "push"](canvasItem);
+		}
+
+		// FOLDERS
+		for (const absolutePath of folderArray) {
+			const folderItem = createFolderItem(absolutePath, vaultPath);
+			if (folderItem) {
+				if (searchAllVaults) {
+					folderItem.subtitle = `[${vaultName}] ` + folderItem.subtitle;
+				}
+				resultsArr.push(folderItem);
+			}
+		}
+
+		// ADDITIONAL OPTIONS WHEN BROWSING A FOLDER
+		if (isInSubfolder) {
+			// New File in Folder
+			resultsArr.push({
+				title: "Create new note in this folder",
+				subtitle: "▸ " + currentFolder,
+				arg: "new",
+				icon: { path: "icons/new.png" },
+			});
+
+			// go up to parent folder
+			resultsArr.push({
+				title: "⬆ Up to Parent Folder",
+				match: "up back parent folder directory browse .. cd",
+				subtitle: "▸ " + parentFolder(currentFolder),
+				arg: parentFolder(currentFolder),
+				icon: { path: "icons/folder.png" },
+				variables: {
+					folder_vault_path: vaultPath,
+				},
+			});
 		}
 	}
 
-	// CANVASES
-	for (const canvas of canvasArray) {
-		const canvasItem = createCanvasItem(canvas, starsAndBookmarks, recentFiles);
-		const isPrioritized = canvasItem.isPrioritized;
-		delete canvasItem.isPrioritized;
-		resultsArr[isPrioritized ? "unshift" : "push"](canvasItem);
-	}
-
-	// FOLDERS
-	for (const absolutePath of folderArray) {
-		const folderItem = createFolderItem(absolutePath, vaultPath);
-		if (folderItem) resultsArr.push(folderItem);
-	}
-
-	// ADDITIONAL OPTIONS WHEN BROWSING A FOLDER
-	if (isInSubfolder) {
-		// New File in Folder
-		resultsArr.push({
-			title: "Create new note in this folder",
-			subtitle: "▸ " + currentFolder,
-			arg: "new",
-			icon: { path: "icons/new.png" },
-		});
-
-		// go up to parent folder
-		resultsArr.push({
-			title: "⬆ Up to Parent Folder",
-			match: "up back parent folder directory browse .. cd",
-			subtitle: "▸ " + parentFolder(currentFolder),
-			arg: parentFolder(currentFolder),
-			icon: { path: "icons/folder.png" },
-			variables: {
-				folder_vault_path: vaultPath,
-			},
-		});
-	}
 	if (resultsArr.length === 0) {
 		resultsArr.push({
 			title: "🚫 No notes found.",

--- a/scripts/open-note.js
+++ b/scripts/open-note.js
@@ -56,10 +56,34 @@ function isAdvancedUriEnabled(vaultPath, configFolder) {
 
 //──────────────────────────────────────────────────────────────────────────────
 
-/** @type {AlfredRun} */
+/**
+ * Reads environment variables to determine the appropriate vault path to use.
+ *
+ * @return {string} vault path
+ */
+function getVaultPath() {
+	return (
+		$.NSProcessInfo.processInfo.environment.objectForKey("note_vault_path").js ||
+		$.NSProcessInfo.processInfo.environment.objectForKey("vault_path").js
+	);
+}
+
+/**
+ * Arguments:
+ *
+ * - argv[0]: the note's relative path, which can include a heading (after `#`) or line number (after `:`).
+ *
+ * Environment variables:
+ *
+ * - note_vault_path: (optional) the note's vault path.
+ * - vault_path: workflow's active vault path, used if note_vault path is not provided.
+ * - open_mode: (optional) Obsidian URI open mode.
+ *
+ * @type {AlfredRun}
+ */
 // biome-ignore lint/correctness/noUnusedVariables: Alfred run
 function run(argv) {
-	const vaultPath = $.getenv("vault_path");
+	const vaultPath = getVaultPath();
 	const vaultNameEnc = encodeURIComponent(vaultPath.replace(/.*\//, ""));
 
 	// VALIDATE that `Advanced URI` is installed and enabled.

--- a/scripts/open-note.js
+++ b/scripts/open-note.js
@@ -13,6 +13,47 @@ function readFile(path) {
 	return ObjC.unwrap(str);
 }
 
+/** @param {string} relativePath */
+function parseRelativePath(relativePath) {
+	const filePath = (relativePath.split("#")[0] || "").split(":")[0] || "";
+	const heading = relativePath.split("#")[1];
+	const lineNum = relativePath.split(":")[1]; // used by `oe` external link search to open at line
+	return { filePath, heading, lineNum };
+}
+
+/**
+ * @param {string} vaultNameEnc
+ * @param {string} filePath
+ * @param {string|undefined} heading
+ * @param {string|undefined} lineNum
+ * @param {string|undefined} openMode
+ */
+function constructOpenNoteUri(vaultNameEnc, filePath, heading, lineNum, openMode) {
+	// https://help.obsidian.md/Extending+Obsidian/Obsidian+URI
+	// https://vinzent03.github.io/obsidian-advanced-uri/actions/navigation
+	const urlComponents = [
+		"obsidian://advanced-uri?",
+		`vault=${vaultNameEnc}`,
+		`&filepath=${encodeURIComponent(filePath)}`,
+		heading ? "&heading=" + encodeURIComponent(heading) : "",
+		lineNum ? "&line=" + encodeURIComponent(lineNum) : "",
+		openMode ? "&openmode=" + openMode : "",
+	];
+	return urlComponents.join("");
+}
+
+/**
+ * @param {string} vaultPath
+ * @param {string} configFolder
+ * @returns {boolean} whether `Advanced URI` plugin is installed and enabled
+ */
+function isAdvancedUriEnabled(vaultPath, configFolder) {
+	const aUriInstalled = fileExists(`${vaultPath}/${configFolder}/plugins/obsidian-advanced-uri`);
+	const pluginList = readFile(`${vaultPath}/${configFolder}/community-plugins.json`);
+	const aUriEnabled = JSON.parse(pluginList).includes("obsidian-advanced-uri");
+	return aUriInstalled && aUriEnabled;
+}
+
 //──────────────────────────────────────────────────────────────────────────────
 
 /** @type {AlfredRun} */
@@ -21,36 +62,24 @@ function run(argv) {
 	const vaultPath = $.getenv("vault_path");
 	const vaultNameEnc = encodeURIComponent(vaultPath.replace(/.*\//, ""));
 
-	// VALIDATE that `Advanced URI` is installed and enabled
-	const configFolder = $.getenv("config_folder");
-	const aUriInstalled = fileExists(`${vaultPath}/${configFolder}/plugins/obsidian-advanced-uri`);
-	const pluginList = readFile(`${vaultPath}/${configFolder}/community-plugins.json`);
-	const aUriEnabled = JSON.parse(pluginList).includes("obsidian-advanced-uri");
-	if (!aUriInstalled || !aUriEnabled) {
+	// VALIDATE that `Advanced URI` is installed and enabled.
+	if (!isAdvancedUriEnabled(vaultPath, $.getenv("config_folder"))) {
 		return '"Advanced URI" plugin not installed or not enabled.';
 	}
 
-	// determine input
-	const input = (argv[0] || "").trim(); // trim to remove trailing \n
-	const relativePath = (input.split("#")[0] || "").split(":")[0] || "";
-	const heading = input.split("#")[1];
-	const lineNum = input.split(":")[1]; // used by `oe` external link search to open at line
+	// determine input; trim to remove trailing \n
+	const smartRelativePath = parseRelativePath((argv[0] || "").trim());
 
 	// DOCS https://vinzent03.github.io/obsidian-advanced-uri/concepts/navigation_parameters#open-mode
 	const openMode = $.NSProcessInfo.processInfo.environment.objectForKey("open_mode").js;
 
-	// construct URI scheme
-	// https://help.obsidian.md/Extending+Obsidian/Obsidian+URI
-	// https://vinzent03.github.io/obsidian-advanced-uri/actions/navigation
-	const urlComponents = [
-		"obsidian://advanced-uri?",
-		`vault=${vaultNameEnc}`,
-		`&filepath=${encodeURIComponent(relativePath)}`,
-		heading ? "&heading=" + encodeURIComponent(heading) : "",
-		lineNum ? "&line=" + encodeURIComponent(lineNum) : "",
-		openMode ? "&openmode=" + openMode : "",
-	];
-	const uri = urlComponents.join("");
+	const openNoteUri = constructOpenNoteUri(
+		vaultNameEnc,
+		smartRelativePath.filePath,
+		smartRelativePath.heading,
+		smartRelativePath.lineNum,
+		openMode,
+	);
 
 	// OPEN FILE
 	// - Delay opening URI scheme until Obsidian is running, URIs do not open
@@ -61,7 +90,7 @@ function run(argv) {
 		Application("Obsidian").launch();
 		delay(1.5);
 	}
-	app.openLocation(uri);
-	console.log("URI opened:", uri);
+	app.openLocation(openNoteUri);
+	console.log("URI opened:", openNoteUri);
 	return;
 }


### PR DESCRIPTION
> ## Problem statement

I wanted to be able to search across all vaults. It has also been requested in https://github.com/chrisgrieser/shimmering-obsidian/issues/63 and https://github.com/chrisgrieser/shimmering-obsidian/issues/100.

## Proposed solution

I added a workflow flag that if enabled, changes o_search to consider files across all vaults.
I also modified some downstream dependencies (open-note, new-note-in-folder) to accept vault path as a dynamic parameter (either per item or as a dynamic env var) rather than the active vault path env var.
c
## AI usage disclosure

I used AI for autocomplete only. The entire design and its flaws are completely on me.

## Checklist

- [x] Variable names follow `camelCase` convention.
- [x] All AI-generated code has been reviewed by a human.
- [x] Documentation (`README.md` and internal workflow docs) has been updated
  for any new or modified functionality.
